### PR TITLE
Disabled input on browse pages

### DIFF
--- a/_notes/dwsync.xml
+++ b/_notes/dwsync.xml
@@ -7,7 +7,7 @@
 <file name="sudokuSubmitBoard.php" server="waws-prod-blu-023.ftp.azurewebsites.windows.net/site/wwwroot/" local="131013892943106081" remote="131014072800000000" Dst="1" />
 <file name="phpFunctions.php" server="waws-prod-blu-023.ftp.azurewebsites.windows.net/site/wwwroot/" local="131013889882791378" remote="131014069800000000" Dst="1" />
 <file name="sudokuSubmitSolution.php" server="waws-prod-blu-023.ftp.azurewebsites.windows.net/site/wwwroot/" local="131013895090004946" remote="131014074600000000" Dst="1" />
-<file name="sudokuBrowseBoards.php" server="waws-prod-blu-023.ftp.azurewebsites.windows.net/site/wwwroot/" local="131013880349206927" remote="131014060200000000" Dst="1" />
+<file name="sudokuBrowseBoards.php" server="waws-prod-blu-023.ftp.azurewebsites.windows.net/site/wwwroot/" local="131013903605462036" remote="131014083000000000" Dst="1" />
 <file name=".gitignore" server="waws-prod-blu-023.ftp.azurewebsites.windows.net/site/wwwroot/" local="131012950422721855" remote="131013927600000000" Dst="1" />
-<file name="sudokuBrowseSolutions.php" server="waws-prod-blu-023.ftp.azurewebsites.windows.net/site/wwwroot/" local="131013885204271220" remote="131014065000000000" Dst="1" />
+<file name="sudokuBrowseSolutions.php" server="waws-prod-blu-023.ftp.azurewebsites.windows.net/site/wwwroot/" local="131013903333069366" remote="131014083000000000" Dst="1" />
 </dwsync>

--- a/sudokuBrowseBoards.php
+++ b/sudokuBrowseBoards.php
@@ -338,6 +338,14 @@
 		});
 	}
 	</script>
+    
+    <script>
+    $( document ).ready(function() {
+    	$( "input" ).prop( "disabled", true );
+		firstBoard();
+	});
+	</script>
+    
 
 </body>
 

--- a/sudokuBrowseSolutions.php
+++ b/sudokuBrowseSolutions.php
@@ -355,6 +355,13 @@
 		});
 	}
 	</script>
+    
+    <script>
+    $( document ).ready(function() {
+    	$( "input" ).prop( "disabled", true );
+		firstSolution();
+	});
+	</script>
 
 </body>
 


### PR DESCRIPTION
Quick fix to prevent user input on browse boards. Also made first board
or solution load on page ready.
